### PR TITLE
Additional functionality regarding the FilePathReference

### DIFF
--- a/Editor/References.meta
+++ b/Editor/References.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 35e4a99513824d2b8923e1a6702165d5
+timeCreated: 1689485669

--- a/Editor/References/FilePathReferenceEditor.cs
+++ b/Editor/References/FilePathReferenceEditor.cs
@@ -1,0 +1,32 @@
+﻿using System.IO;
+using SVT.References;
+using UnityEditor;
+using UnityEngine;
+
+namespace SVT.Editor.References
+{
+    [CustomEditor(typeof(FilePathReference))]
+    public class FilePathReferenceEditor : UnityEditor.Editor
+    {
+        public override void OnInspectorGUI()
+        {
+            base.OnInspectorGUI();
+            var filePathReference = target as FilePathReference;
+            if (!GUILayout.Button("Create Directory")) return;
+            CreateDirectory(filePathReference);
+        }
+
+        private void CreateDirectory(FilePathReference filePathReference)
+        {
+            if (Directory.Exists(filePathReference.DirectoryPath))
+            {
+                Debug.LogWarning($"{filePathReference.DirectoryPath} already exists.");
+                return;
+            }
+
+            Directory.CreateDirectory(filePathReference.DirectoryPath);
+            Debug.Log($"{filePathReference.DirectoryPath} created.");
+            AssetDatabase.Refresh();
+        }
+    }
+}

--- a/Editor/References/FilePathReferenceEditor.cs.meta
+++ b/Editor/References/FilePathReferenceEditor.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 8ceceb52346340cdb9b6e22050906445
+timeCreated: 1689485682

--- a/Runtime/References/FilePathReference.cs
+++ b/Runtime/References/FilePathReference.cs
@@ -15,7 +15,29 @@ namespace SVT.References
     public class FilePathReference : ScriptableObject
     {
         [SerializeField] private AssetPathType assetPathType;
-        [SerializeField] private string directory;
+        [SerializeField] private string rootDirectory;
+        [SerializeField] private bool isRootHidden;
+        [SerializeField] private string endPoint;
+        [SerializeField] private bool isEndpointHidden;
+
+        public string RootDirectory => isRootHidden ? $"{rootDirectory}~" : rootDirectory;
+        public string EndPoint => isEndpointHidden ? $"{endPoint}~" : endPoint;
+
+        public string DirectoryPath
+        {
+            get
+            {
+                var isRootEmpty = string.IsNullOrEmpty(rootDirectory);
+                var isEndPointEmpty = string.IsNullOrEmpty(endPoint);
+                return isRootEmpty switch
+                {
+                    true when isEndPointEmpty => AssetPath,
+                    false when isEndPointEmpty => $"{AssetPath}/{RootDirectory}",
+                    true when !isEndPointEmpty => $"{AssetPath}/{EndPoint}",
+                    _ => $"{AssetPath}/{RootDirectory}/{EndPoint}/"
+                };
+            }
+        }
 
         public string AssetPath
         {
@@ -31,7 +53,5 @@ namespace SVT.References
                 };
             }
         }
-
-        public string DirectoryPath => string.IsNullOrEmpty(directory) ? $"{AssetPath}/" : $"{AssetPath}/{directory}/";
     }
 }


### PR DESCRIPTION
- Now has a create directory button in the inspector which checks and creates the directory
- Splits the root directory from the endpoint which should allow for easier readability for long paths
- Adds toggle to hide the root or endpoint from Unity, which means that files within those folders would not be imported